### PR TITLE
Исправить примагничивание новых линий маршрута

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -294,6 +294,7 @@ function showRoutesMessage(message, isError = false) {
 }
 
 let isSnappingRoute = false;
+let shouldSnapRouteAgain = false;
 
 async function snapFeatureGroup(routeId, features, shouldFit = false) {
   const geometry = getRouteGeometryFromFeatures(features);
@@ -362,6 +363,10 @@ async function snapFullCurrentRoute() {
 
 async function snapCurrentEditingRoute(force = false) {
   if (isSnappingRoute) {
+    if (!force && snapToggle.checked) {
+      shouldSnapRouteAgain = true;
+    }
+
     return;
   }
 
@@ -383,6 +388,11 @@ async function snapCurrentEditingRoute(force = false) {
   } finally {
     isSnappingRoute = false;
     snapRouteBtn.disabled = false;
+
+    if (shouldSnapRouteAgain && snapToggle.checked) {
+      shouldSnapRouteAgain = false;
+      setTimeout(() => snapCurrentEditingRoute(false), 0);
+    }
   }
 }
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -181,7 +181,7 @@ authPasswordInput.addEventListener("keydown", (evt) => {
 updateAuthStatus();
 
 const DRAFT_ROUTE_ID = "__draft_route__";
-const SNAP_CONTEXT_LINES_COUNT = 10;
+const SNAP_CONTEXT_LINES_COUNT = 3;
 const SNAP_FULL_ROUTE_CHUNK_SIZE = 10;
 
 let currentRouteId = null;

--- a/frontend/js/map.js
+++ b/frontend/js/map.js
@@ -3,6 +3,12 @@ let activeLayer = "osm";
 let drawInteraction = null;
 let selectInteraction = null;
 let modifyInteraction = null;
+let routeFeatureOrder = 0;
+
+function assignRouteFeatureOrder(feature) {
+  routeFeatureOrder += 1;
+  feature.set("routeOrder", routeFeatureOrder);
+}
 
 function getLineWidth() {
   const zoom = map.getView().getZoom() || 12;
@@ -77,13 +83,20 @@ map.getView().on("change:resolution", () => {
 });
 
 function getRouteFeatures(routeId = null) {
+  const sortByRouteOrder = (a, b) => {
+    return (a.get("routeOrder") || 0) - (b.get("routeOrder") || 0);
+  };
+
   if (!routeId) {
-    return source.getFeatures();
+    return source.getFeatures().sort(sortByRouteOrder);
   }
 
-  return source.getFeatures().filter((feature) => {
-    return String(feature.get("routeId")) === String(routeId);
-  });
+  return source
+    .getFeatures()
+    .filter((feature) => {
+      return String(feature.get("routeId")) === String(routeId);
+    })
+    .sort(sortByRouteOrder);
 }
 
 function getLastRouteFeatures(routeId, limit = 10) {
@@ -173,6 +186,7 @@ function addRouteGeometryToMap(geometry, routeId = null) {
       feature.set("routeId", String(routeId));
     }
 
+    assignRouteFeatureOrder(feature);
     source.addFeature(feature);
   }
 

--- a/frontend/js/tools.js
+++ b/frontend/js/tools.js
@@ -65,6 +65,10 @@ function enableBrushMode() {
       event.feature.set("routeId", getEditingRouteId());
     }
 
+    if (typeof assignRouteFeatureOrder === "function") {
+      assignRouteFeatureOrder(event.feature);
+    }
+
     if (typeof markRouteAsChanged === "function") {
       setTimeout(markRouteAsChanged, 0);
     }


### PR DESCRIPTION
## Что изменено

- Добавлен стабильный порядок участков маршрута на фронтенде.
- Перемагничивание теперь выбирает последние 3 участка маршрута, а не 10.
- Новые нарисованные линии сразу получают порядковый номер.
- Добавлена очередь, чтобы запросы не терялись, если предыдущий snap ещё выполняется.

## Зачем

OpenLayers не гарантирует порядок `getFeatures()`, поэтому выбор последних участков через исходный порядок features мог отправлять на snap не только что нарисованную линию, а старые участки маршрута. Из-за этого backend успешно примагничивал данные, но визуально новая линия могла оставаться без изменений.